### PR TITLE
Updated some old naming conventions around to work properly

### DIFF
--- a/_calendar.dart
+++ b/_calendar.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'volleymatic_model.dart';
-import 'package:intl/intl.dart';
 
 
 class Calendar extends StatefulWidget {

--- a/_schedule.dart
+++ b/_schedule.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:volley_matic/volley_matic.dart';
+import 'volleymatic_model.dart';
 
 class Schedule extends StatefulWidget {
   const Schedule({super.key, required VolleymaticModel model});

--- a/account_settings.dart
+++ b/account_settings.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:volley_matic/volley_matic.dart';
+import 'volleymatic_model.dart';
 
 class Settings extends StatefulWidget {
   const Settings({super.key, required VolleymaticModel model});

--- a/account_settings_loggedout.dart
+++ b/account_settings_loggedout.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:volley_matic/volley_matic.dart';
+import 'volleymatic_model.dart';
 
 class SettingsLogOut extends StatefulWidget {
   const SettingsLogOut({super.key, required VolleymaticModel model});

--- a/main_app.dart
+++ b/main_app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'volleymatic_model.dart';
-import 'upcoming_tournaments.dart';
+import 'upcoming_tournaments_widget.dart';
 import 'schedule_widget.dart';
-import 'standings.dart';
+import '_standings.dart';
 import 'account_settings.dart';
 
 
@@ -29,7 +29,7 @@ class _MainAppState extends State<MainApp> {
     ),
     Consumer<VolleymaticModel>(
       builder: (context, volleymaticModel, child) =>
-          AccountSettings(model: volleymaticModel),
+          Settings(model: volleymaticModel),
     ),
   ];
   int selectedTabIndex = 0;

--- a/schedule_widget.dart
+++ b/schedule_widget.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'volleymatic_model.dart';
 import 'game.dart';
-import 'package:tournament_bracket/tournament_bracket.dart';
+import 'tournament_bracket.dart';
 import 'team.dart';
 import 'match_details.dart';
 

--- a/upcoming_tournaments_widget.dart
+++ b/upcoming_tournaments_widget.dart
@@ -1,9 +1,9 @@
 // ignore_for_file: prefer_const_constructors_in_immutables, prefer_const_constructors
 
-import 'package:final_project_navigation/add_tournament.dart';
-import 'package:final_project_navigation/schedule_widget.dart';
+import 'add_tournament.dart';
+import 'schedule_widget.dart';
 import 'package:flutter/material.dart';
-import 'calendar.dart';
+import '_calendar.dart';
 import 'volleymatic_model.dart';
 
 class UpcomingTournaments extends StatefulWidget {


### PR DESCRIPTION
It is tragically missing both login.dart, and tournament_bracket.dart. Seemingly also behind in a volleyMatic._model.dart commit because recent commits use new methods that don't exist in the file.